### PR TITLE
Fix background overlay branch return

### DIFF
--- a/lib/flushbar_route.dart
+++ b/lib/flushbar_route.dart
@@ -150,7 +150,7 @@ class FlushbarRoute<T> extends OverlayRoute<T> {
     }
 
     if (_filterColorAnimation != null) {
-      AnimatedBuilder(
+      return AnimatedBuilder(
         animation: _filterColorAnimation!,
         builder: (context, child) {
           return Container(


### PR DESCRIPTION
## Summary
- fix `_createBackgroundOverlay` so the color filter branch returns an `AnimatedBuilder`

## Testing
- `dart format lib/flushbar_route.dart` *(fails: dart not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acd94bb80832a8e7a6bc3f8257b25