### PR TITLE
Fix test description

### DIFF
--- a/test/another_flushbar_test.dart
+++ b/test/another_flushbar_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('Test Flushbar basic inicialization', () async {
+  test('Test Flushbar basic initialization', () {
     final flushbar = Flushbar(message: 'This is a test');
     expect(flushbar.title, null);
     expect(flushbar.message, 'This is a test');


### PR DESCRIPTION
## Summary
- rename test description in `another_flushbar_test.dart`
- drop unused `async` keyword

## Testing
- `dart format test/another_flushbar_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad068c424832abe87c72fe7c6214a